### PR TITLE
Add support for PIE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "pecl/pecl-database-dbase",
+    "type": "php-ext",
+    "license": "PHP-3.01",
+    "description": "dBase database file access functions",
+    "require": {
+        "php": ">= 7.0"
+    },
+    "php-ext": {
+        "extension-name": "dbase"
+    }
+}


### PR DESCRIPTION
Adds support for [PIE](https://github.com/php/pie).

Once merged, a maintainer would need to add this repo's URL to https://packagist.org/packages/submit :)

More info/documentation can be read on: https://github.com/php/pie/blob/main/docs/extension-maintainers.md
